### PR TITLE
Add collaboration folder including past cartesian biweekly minutes

### DIFF
--- a/collaboration/cartesian-biweekly/2020.06.23-GT4Py-cartesian-bi-weekly.md
+++ b/collaboration/cartesian-biweekly/2020.06.23-GT4Py-cartesian-bi-weekly.md
@@ -1,0 +1,73 @@
+# 2020/06/23 GT4Py bi-weekly
+
+# Participants
+
+@Jeremy M @Rhea G @Mark C @Eddie D @Tobias W @Oli F …
+
+# Action Points
+
+Team: discuss solution to pass FV3 stencils with validation tests to partners
+Team: members should review storage GDP and comment — [GridTools/gt4py#28](https://github.com/GridTools/gt4py/pull/28)
+All: will write README explaining domain and origin, with diagrams
+@Johann D will document specific issues that arose with automatic domain and origin in the region GDP discussion — [GridTools/gt4py#24](https://github.com/GridTools/gt4py/pull/24)
+
+# Discussion Points
+## Vulcan Status Update
+****
+FV3 porting status and issues (frontend)
+
+- Full dycore ported!
+- Only a few small issues came up over the last few weeks
+    - Would like to get reproducers, and open github issues
+
+Dawn backend correctness
+
+- CPU: Almost all FV3 stencils validate
+- GPU: ?
+
+Parallel model
+
+- Code generated with CUDA backend fails to verify on a select few clang-gridtools stencil tests 
+
+
+## Dawn backend merge into master
+
+Tests pass on Enrique’s machine
+Status: two branches off master, that look different but behave similarly
+Will rebase branch against master and fix carefully
+Have plan to merge soon, regardless of state
+
+
+## Math Functions
+
+Dawn IR needs new nodes for these functions
+Dawn could use general-purpose function nodes for now
+Tobias will coordinate with Enrique in the next few days on implementation details
+
+
+## Storages
+
+Plan to split into two GDPs
+
+1. Storage implementation interface as python objects — [GridTools/gt4py#28](https://github.com/GridTools/gt4py/pull/28)
+2. **Lower-dimensional fields**
+
+Read and comment on (1) soon!
+
+## Application story: Quantities in FV3
+
+Overview document: [+2020-06-22 Quantity Snapshot](https://paper.dropbox.com/doc/2020-06-22-Quantity-Snapshot-bWtgw0D91vfAwHtBjYuef) 
+
+
+## Regions
+
+Clarify domain and origin
+
+- Domain could be required unless output fields all have the same size
+
+Discussion: [GridTools/gt4py#24](https://github.com/GridTools/gt4py/pull/24)
+Implementation: [GridTools/gt4py#36](https://github.com/GridTools/gt4py/pull/36)
+
+Status: Implemented in frontend, and IRs
+Current work: Python backends, dawn backend
+

--- a/collaboration/cartesian-biweekly/2020.07.07-GT4Py-cartesian-bi-weekly.md
+++ b/collaboration/cartesian-biweekly/2020.07.07-GT4Py-cartesian-bi-weekly.md
@@ -1,0 +1,73 @@
+# 2020/07/07 GT4Py bi-weekly
+
+# Participants
+
+@Tobias W @Rhea G Linus, Enrique, @Eddie D, @Oliver E 
+
+# Action Points
+
+@Enrique G. P Start collecting ideas for explicit indexing and directional offsets for fields in [doc](https://docs.google.com/document/d/1J0i89ZqITf-s27CrE215OsVI1MWSXx_aC2TZErxbEI8/edit#)
+@Johann D Will send around poll to find time for a gt4py mini-workshop
+@Johann D Will setup a meeting to review GDP implementation with gt4py team
+
+# Review action points from last meeting
+
+Team: discuss solution to pass FV3 stencils with validation tests to partners
+
+- Second dawn PR is making progress
+- At some point FV3 dycore will be an open repo, but may not be advertised until more digestible
+
+Team: members should review storage GDP and comment — [GridTools/gt4py#28](https://github.com/GridTools/gt4py/pull/28)
+
+- Quantity work gave some interface ideas
+- Want to ensure that unstructured grids are naturally supported in storages
+
+All: will write README explaining domain and origin, with diagrams
+@Johann D will document specific issues that arose with automatic domain and origin in the region GDP discussion — [GridTools/gt4py#24](https://github.com/GridTools/gt4py/pull/24)
+
+- Workaround: specify domain and origin at all times
+# Discussion Points
+## Storages
+- API feedback
+- Lower dimensional fields are high priority for fv3 and other codes. Is there a way that Johann could help get a prototype working sooner?
+
+
+## Dawn backend merge into master
+
+Dawn PR is in gt4py repo, will be reviewed soon
+Parallel model merge in dawn should not affect gt4py interface
+Create 0.0.3 tag in dawn after merge
+
+
+## Math Functions
+
+Tobias is on it!!!
+Splitting intrinsic and non-intrinsic functions
+
+
+## FV3 Update
+
+Quantity?
+Plan to test fv3 stencils with gt4py after dawn merge of the parallel model
+
+
+## Regions
+
+Would like to get review in the next week
+Clarify domain and origin
+
+- Domain could be required unless output fields all have the same size
+
+
+## Runtime vertical splits
+
+Make grid-data available
+Runtime values for vertical splits?
+
+
+## Features
+
+Directional offsets
+Lookup tables
+Absolute indexing in k
+

--- a/collaboration/cartesian-biweekly/2020.07.21.GT4Py-cartesian-bi-weekly.md
+++ b/collaboration/cartesian-biweekly/2020.07.21.GT4Py-cartesian-bi-weekly.md
@@ -1,0 +1,75 @@
+# 2020/07/21 GT4Py bi-weekly
+
+# Action Points
+
+**Review of action points of last meeting.**
+
+[ ] @Enrique G. P Start collecting ideas for explicit indexing and directional offsets for fields in [doc](https://docs.google.com/document/d/1J0i89ZqITf-s27CrE215OsVI1MWSXx_aC2TZErxbEI8/edit#)
+- @Enrique G. P will help prioritize the items
+[ ] @Johann D Will send around poll to find time for a gt4py mini-workshop
+- Purpose of the meeting will be to decide syntax and other details related to the workshop topics
+- Focus on 1-2 issues
+[ ] @Johann D Will setup a meeting to review GDP implementation with gt4py team
+
+**Action points of this meeting:**
+
+[x] Complete Doodle poll:
+    - [https://doodle.com/poll/zn2nhrv46et9hiem](https://doodle.com/poll/zn2nhrv46et9hiem)
+****[ ] Submit items for mini-workshop in this document:
+    - [https://docs.google.com/document/d/1hFQ0TfO7fAiz7Xh-LE3RQucesI_k0tuCGku6pmz9qnY/edit](https://docs.google.com/document/d/1hFQ0TfO7fAiz7Xh-LE3RQucesI_k0tuCGku6pmz9qnY/edit)
+[x] Review Region GDP in light of figure discussion
+[ ] Schedule a meeting to discuss before next instance of this meeting
+[ ] Characterize minimum stencil overhead
+[ ] Add absolute indexing and offset-center writes to the list of items in the GTScript syntax workshop
+[ ] Select examples for off-center writes
+[ ] Check whether no-check functionality already in StencilObject
+[ ] Determine best way to share meeting notes — prefer a single link
+[ ] Convention for GT4Py issue submission — will iterate
+[ ] Present results of student projects that @Oli F and @Tobias W are working on — deadline is Aug 7
+# Discussion Points
+## Math functions
+- @Tobias W is working on this from the SIR side in Dawn and from the GT4Py side
+
+
+## Stencil overhead
+- Observed ~5ms overhead
+    - Known issue
+    - Experiment with how the overhead scales with number of input fields
+    - Python code generated in modules will be removed
+    - Characterize pybind11 overhead — this will be the minimum overhead
+    - What is the minimum acceptable overhead (upper bound)? — within a few percent of the dycore runtime
+    - Not currently a high priority for GT4py team
+    - @Johann D  is planning to submit PR for debug mode
+    - Functionality might already be there — need to be check
+
+
+## Regions
+- @Enrique G. P and @Johann D had a meeting to discuss the Regions GDP
+- Discussion of @Enrique G. P ‘s figure:
+![](https://paper-attachments.dropbox.com/s_29BD4C5C5F9BC0EB23379F0306EA720B6B6E8B4D3E55F6D0538BC148364F1815_1595348347809_domain_regions_ink.svg)
+
+    - Fields are aligned for the local compute domain via origins
+    - Local compute domains need to be mapped to global application domain and its halos
+    - Halos can be used to locate corner and edge points
+    - Temporaries are generated on the fly — compute temporary origins from those of input fields
+    - Need a global frame of reference — each field could store its location on the global grid, maybe only one field needs this, others can compute from origin
+    - Information will also be needed for halo updates
+    - Halo and origin are separate concepts
+    - What does the region object need to know or compute?
+    - Should the generated code answer these questions? — will be more efficient than Python
+- @Johann D  plans to proceed with reference implementation
+
+
+## Vertical treatment
+- Absolute indexing
+- Off-center writes
+    - Always in the vertical
+    - Field adapters to shift the fields
+    - Shift the output field and write into the shifted field — will appear as centered write
+    - Can one pass the same field with different origins?
+    - Separate the vertical computations from the stencil
+    - Could be done in the GT4Py frontend
+    - How will analysis work in Dawn, e.g., field versioning?
+- These to be added to the GTScript syntax workshop
+- Increasing in priority as more FV3 code is ported
+

--- a/collaboration/cartesian-biweekly/2020.08.03-GT4Py-cartesian-bi-weekly.md
+++ b/collaboration/cartesian-biweekly/2020.08.03-GT4Py-cartesian-bi-weekly.md
@@ -1,0 +1,108 @@
+# 2020/08/03 GT4Py bi-weekly
+
+# Action Points
+
+**Review of action points of last meeting:**
+
+[x] Complete Doodle poll:
+    - [https://doodle.com/poll/zn2nhrv46et9hiem](https://doodle.com/poll/zn2nhrv46et9hiem)
+[ ] Submit items for mini-workshop in this document:
+    - [https://docs.google.com/document/d/1hFQ0TfO7fAiz7Xh-LE3RQucesI_k0tuCGku6pmz9qnY/edit](https://docs.google.com/document/d/1hFQ0TfO7fAiz7Xh-LE3RQucesI_k0tuCGku6pmz9qnY/edit)
+[x] Review Region GDP in light of figure discussion
+[x] Schedule a meeting to discuss before next instance of this meeting
+[x] Characterize minimum stencil overhead
+[x] Add absolute indexing and offset-center writes to the list of items in the GTScript syntax workshop
+[x] Select examples for off-center (vertically) writes
+[x] Check whether no-check functionality already in StencilObject
+[x] Determine best way to share meeting notes — prefer a single link
+[x] Convention for GT4Py issue submission — will iterate
+[x] Present results of student projects that @Oli F and @Tobias W are working on — deadline is Aug ~~7~~ 16 - present on 18th
+
+Rhea will file an issue to share off-center write examples
+Johann will review the two ideas for regions and resolve differences
+Enrique will add ideas to the syntax workshop
+
+# Discussion Points
+## Review PRs, please!
+1. Keep PRs as drafts until they are ready for review
+2. Assign someone - may be re-assigned as necessary
+
+**Ready for review**
+
+- ~~Reduce overhead - https://github.com/GridTools/gt4py/pull/117~~
+- ~~Add BOOL - https://github.com/GridTools/gt4py/pull/129~~
+- Math functions - https://github.com/GridTools/gt4py/pull/125
+
+**Needs a test**
+
+- Dawn extent fix - https://github.com/GridTools/gt4py/pull/101
+
+
+## Interesting new issues
+- Scalars become temporary fields - https://github.com/GridTools/gt4py/issues/103
+- Dimensions of temporaries - https://github.com/GridTools/gt4py/issues/107
+- Determining type inside an if statement - https://github.com/GridTools/gt4py/issues/106
+- Functions calls with scalar literals - https://github.com/GridTools/gt4py/issues/104
+
+
+## Dialect Workshop
+- **18, 19,** 21st August are best, but Matthias cannot join
+- Reminder: add issues to the document
+    - Directional offsets
+    - Absolute k indexing
+    - Named regions
+
+
+## Backend Compatibility
+- Race condition PR in progress - https://github.com/GridTools/gt4py/pull/121
+- Numpy backend warns about division by zero
+
+
+    with computation(PARALLEL), interval(…):
+        tmp = field[0,0,1]
+        tmp2 = tmp + 1
+        field = tmp2
+    
+        if __INLINED(flag):
+            tmp = field[1,0,0]
+            tmp2 = tmp + 1
+            field = tmp2
+
+
+## End to End Tests
+- Discuss ideas for how this could be structured
+- Increase number of integration tests, or put them elsewhere?
+- Existing types of tests: unit tests, code generation
+
+
+- Do not make gt4py repo dependent on regression tests
+- Eventually: mergeable/merged PRs should trigger dycore builds, and tests should be visible
+- If we find problems, add reproducers as regressions tests
+
+
+## Regions
+- Agreement on a lightweight splitter-based approach. Example:
+    @gtscript.stencil(splitters={I: ['i0', 'ie'], J: ['j0', 'je']})
+    def divergence_corner(...):
+      from __splitters__ import i0, ie, j0, je
+      with computation(FORWARD), interval(...):
+        uf = (u - 0.25*(va[0, -1, 0] + va)*(cos_sg4[0, -1, 0] + cos_sg2))  \
+                                   *dyc*0.5*(sin_sg4[0, -1, 0] + sin_sg2)
+        with region[i0 : i0 + 1, :], region[ie - 1 : ie, :]:
+          uf = u*dyc*0.5*(sin_sg4[0, -1, 0] + sin_sg2)
+    
+        vf = (v - 0.25*(ua[-1, 0, 0] + ua)*(cos_sg3[-1, 0, 0] + cos_sg1))  \
+                                   *dxc*0.5*(sin_sg3[-1, 0, 0] + sin_sg1)
+        with region[:, j0 : j0 + 1], region[:, je - 1 : je]:
+          vf = v*dxc*0.5*(sin_sg3[-1, 0, 0] + sin_sg1)
+    
+        divg_d = rarea_c * (vf[0, -1, 0] - vf + uf[-1, 0, 0] - uf)
+        with region[i0 : i0 + 1, j0 : j0 + 1], region[ie - 1 : ie, j0 : j0 + 1]:
+          divg_d = rarea_c * (-vf + uf[-1, 0, 0] - uf)
+        with region[i0 : i0 + 1, je - 1 : je], region[ie - 1 : ie, je - 1 : je]:
+          divg_d = rarea_c * (vf[0, -1, 0] + uf[-1, 0, 0] - uf)
+
+
+## Review status of GDP3-Duck Storages
+- Status update on the state of the GDP3 implementation including 1D/2D fields
+


### PR DESCRIPTION
- Create a new `collaboration` folder to store documents related to meetings, workshops and further activities involving other partners.
- Add documents from the last bi-weekly meetings on cartesian grids